### PR TITLE
Fix transform logic to send `source_name`

### DIFF
--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -25,7 +25,7 @@ def transform(device, observation):
     device_name = device_info.pop("devicename")
 
     return {
-        "name": device_name,
+        "source_name": device_name,
         "source": device_imei,
         "type": "tracking-device",
         "subject_type": "vehicle",


### PR DESCRIPTION
This pull request includes a change to the `transform` function in the `app/actions/handlers.py` file. The change updates the key name in the return dictionary to improve clarity.

* [`app/actions/handlers.py`](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L28-R28): Changed the key `"name"` to `"source_name"` in the return dictionary of the `transform` function.