### PR TITLE
GUNDI-4530: Fix expired token support & add observations limit

### DIFF
--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -155,10 +155,7 @@ async def get_devices(integration, base_url, auth):
                         action_id="pull_observations",
                         source_id="token"
                     )
-                    raise ProTrackTokenExpiredException(
-                        error=Exception(),
-                        message=f"Token expired. Integration {integration.id}"
-                    )
+                    raise ProTrackTokenExpiredException(message=f"Token expired. Integration {integration.id}")
                 logger.error(f"{devices_url} returned error: {parsed_response.get('message')}")
                 return None
             return [DeviceResponse.parse_obj(item) for item in parsed_response.get('record')]
@@ -195,10 +192,7 @@ async def get_playback_observations(integration, base_url, config, auth):
                             action_id="pull_observations",
                             source_id="token"
                         )
-                        raise ProTrackTokenExpiredException(
-                            error=Exception(),
-                            message=f"Token expired. Integration {integration.id}"
-                        )
+                        raise ProTrackTokenExpiredException(message=f"Token expired. Integration {integration.id}")
                     logger.error(f"{playback_url} returned error: {parsed_response.get('message')}")
                     return None
                 obs = parsed_response.get('record').split(";") if parsed_response.get('record') else []

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -48,7 +48,7 @@ class PlaybackResponse(pydantic.BaseModel):
 
 
 class ProTrackUnauthorizedException(Exception):
-    def __init__(self, error: Exception, message: str, status_code=401):
+    def __init__(self, message: str, error: Exception = None, status_code=401):
         self.status_code = status_code
         self.message = message
         self.error = error
@@ -56,7 +56,7 @@ class ProTrackUnauthorizedException(Exception):
 
 
 class ProTrackTokenExpiredException(Exception):
-    def __init__(self, error: Exception, message: str, status_code=PROTRACK_ERROR_CODE_EXPIRED_TOKEN):
+    def __init__(self, message: str, error: Exception = None, status_code=PROTRACK_ERROR_CODE_EXPIRED_TOKEN):
         self.status_code = status_code
         self.message = message
         self.error = error
@@ -82,7 +82,7 @@ async def get_token(integration, base_url, auth):
             if not token:
                 message = f"Failed to authenticate with integration {integration.id} using {auth}"
                 logger.error(message)
-                raise ProTrackUnauthorizedException(error=Exception(), message=message)
+                raise ProTrackUnauthorizedException(message)
             await state_manager.set_state(
                 integration_id=integration.id,
                 action_id="pull_observations",

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -149,6 +149,7 @@ async def get_devices(integration, base_url, auth):
             if code != 0:
                 if code == PROTRACK_ERROR_CODE_EXPIRED_TOKEN:
                     # Token expired, remove it from state and retry
+                    logger.info("Token expired, remove it from state and retry...")
                     await state_manager.delete_state(
                         integration_id=integration.id,
                         action_id="pull_observations",
@@ -216,4 +217,5 @@ async def get_playback_observations(integration, base_url, config, auth):
         keys = ["longitude", "latitude", "gpstime", "speed", "course"]
         parsed_obs = [PlaybackResponse.parse_obj(dict(zip(keys, obs))) for obs in extracted_obs]
 
-        return parsed_obs
+        # Get only the number of records set in max_observations value within the playback config
+        return sorted(parsed_obs, key=lambda x: x.gpstime, reverse=True)[:config.max_observations]

--- a/app/actions/client.py
+++ b/app/actions/client.py
@@ -55,6 +55,14 @@ class ProTrackUnauthorizedException(Exception):
         super().__init__(f"'{self.status_code}: {self.message}, Error: {self.error}'")
 
 
+class ProTrackTokenExpiredException(Exception):
+    def __init__(self, error: Exception, message: str, status_code=PROTRACK_ERROR_CODE_EXPIRED_TOKEN):
+        self.status_code = status_code
+        self.message = message
+        self.error = error
+        super().__init__(f"'{self.status_code}: {self.message}, Error: {self.error}'")
+
+
 def generate_md5_hash(input_string):
     md5_hash = hashlib.md5()
     md5_hash.update(input_string.encode('utf-8'))
@@ -74,7 +82,7 @@ async def get_token(integration, base_url, auth):
             if not token:
                 message = f"Failed to authenticate with integration {integration.id} using {auth}"
                 logger.error(message)
-                raise ProTrackUnauthorizedException(message)
+                raise ProTrackUnauthorizedException(error=Exception(), message=message)
             await state_manager.set_state(
                 integration_id=integration.id,
                 action_id="pull_observations",
@@ -118,7 +126,7 @@ async def get_auth_response(integration_id, url, auth):
             return response.text
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=4.0, wait_jitter=5.0, wait_max=32.0)
+@stamina.retry(on=(httpx.HTTPError, ProTrackTokenExpiredException), wait_initial=4.0, wait_jitter=5.0, wait_max=32.0, attempts=2)
 async def get_devices(integration, base_url, auth):
     async with httpx.AsyncClient(timeout=120) as session:
         logger.info(f"-- Getting devices for integration ID: {integration.id} Account: {auth.account} --")
@@ -146,7 +154,10 @@ async def get_devices(integration, base_url, auth):
                         action_id="pull_observations",
                         source_id="token"
                     )
-                    return await get_devices(integration, base_url, auth)
+                    raise ProTrackTokenExpiredException(
+                        error=Exception(),
+                        message=f"Token expired. Integration {integration.id}"
+                    )
                 logger.error(f"{devices_url} returned error: {parsed_response.get('message')}")
                 return None
             return [DeviceResponse.parse_obj(item) for item in parsed_response.get('record')]
@@ -154,13 +165,16 @@ async def get_devices(integration, base_url, auth):
             return response.text
 
 
-@stamina.retry(on=httpx.HTTPError, wait_initial=4.0, wait_jitter=5.0, wait_max=32.0)
-async def get_playback_observations(integration, base_url, config):
+@stamina.retry(on=(httpx.HTTPError, ProTrackTokenExpiredException), wait_initial=4.0, wait_jitter=5.0, wait_max=32.0, attempts=2)
+async def get_playback_observations(integration, base_url, config, auth):
     async with httpx.AsyncClient(timeout=120) as session:
         extracted_obs = []
 
         playback_url = f"{base_url}/playback"
         has_data = True
+
+        token = await get_token(integration, base_url, auth)
+        config.access_token = token
 
         while has_data:
             logger.info(f"-- Getting playback observations for integration ID: {integration.id} Device: {config.imei} --")
@@ -180,7 +194,10 @@ async def get_playback_observations(integration, base_url, config):
                             action_id="pull_observations",
                             source_id="token"
                         )
-                        return await get_playback_observations(integration, base_url, config)
+                        raise ProTrackTokenExpiredException(
+                            error=Exception(),
+                            message=f"Token expired. Integration {integration.id}"
+                        )
                     logger.error(f"{playback_url} returned error: {parsed_response.get('message')}")
                     return None
                 obs = parsed_response.get('record').split(";") if parsed_response.get('record') else []

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -19,11 +19,11 @@ class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
 
 class PullObservationsConfig(PullActionConfiguration):
     default_lookback_days: int = FieldWithUIOptions(
-        2,
+        3,
         title="Default Lookback Days",
         description="Initial number of days to look back for observations Min: 1, Default: 3",
         ge=1,
-        le=3,
+        le=5,
         ui_options=UIOptions(
             widget="range",
         )
@@ -36,6 +36,7 @@ class PlaybackConfig(PullActionConfiguration):
     imei: str
     begintime: int
     endtime: int
+    max_observations: int = 1000
 
 
 def get_auth_config(integration):

--- a/app/actions/configurations.py
+++ b/app/actions/configurations.py
@@ -19,19 +19,19 @@ class AuthenticateConfig(AuthActionConfiguration, ExecutableActionMixin):
 
 class PullObservationsConfig(PullActionConfiguration):
     default_lookback_days: int = FieldWithUIOptions(
-        3,
+        2,
         title="Default Lookback Days",
         description="Initial number of days to look back for observations Min: 1, Default: 3",
         ge=1,
-        le=5,
+        le=3,
         ui_options=UIOptions(
-            widget="range",  # This will be rendered ad a range slider
+            widget="range",
         )
     )
 
 
 class PlaybackConfig(PullActionConfiguration):
-    access_token: str
+    access_token: str = None
     device_info: dict
     imei: str
     begintime: int

--- a/app/actions/handlers.py
+++ b/app/actions/handlers.py
@@ -97,7 +97,7 @@ async def action_pull_observations(integration, action_config: PullObservationsC
     except client.ProTrackUnauthorizedException as e:
         message = f"Failed to authenticate with integration {integration.id} using {auth_config}. Exception: {e}"
         logger.exception(message)
-        raise client.ProTrackUnauthorizedException(error=e, message=message)
+        raise
 
 
 @activity_logger()
@@ -141,4 +141,4 @@ async def action_playback(integration, action_config: PlaybackConfig):
     except client.ProTrackUnauthorizedException as e:
         message = f"Failed to authenticate with integration {integration.id}. Exception: {e}"
         logger.exception(message)
-        raise client.ProTrackUnauthorizedException(error=e, message=message)
+        raise

--- a/app/actions/tests/test_handlers.py
+++ b/app/actions/tests/test_handlers.py
@@ -105,6 +105,7 @@ async def test_action_playback_extracts_observations(
     mocker.patch("app.services.state.IntegrationStateManager.set_state", return_value=None)
 
     integration = integration_v2
+    integration.configurations[2].data = {"account": "user", "password": "pass"}
     action_config = PlaybackConfig(access_token="fake_token", device_info={"imei": "12345", "devicename": "device"}, imei="12345", begintime=0, endtime=0)
 
     result = await action_playback(integration, action_config)
@@ -117,6 +118,7 @@ async def test_action_playback_no_observations(mocker, integration_v2, mock_publ
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
 
     integration = integration_v2
+    integration.configurations[2].data = {"account": "user", "password": "pass"}
     action_config = PlaybackConfig(access_token="fake_token", device_info={"imei": "12345"}, imei="12345", begintime=0, endtime=0)
 
     result = await action_playback(integration, action_config)
@@ -143,6 +145,7 @@ async def test_action_playback_http_error(mocker, integration_v2, mock_publish_e
     mocker.patch("app.services.action_runner.publish_event", mock_publish_event)
 
     integration = integration_v2
+    integration.configurations[2].data = {"account": "user", "password": "pass"}
     action_config = PlaybackConfig(access_token="fake_token", device_info={"imei": "12345"}, imei="12345", begintime=0, endtime=0)
 
     with pytest.raises(httpx.HTTPStatusError):


### PR DESCRIPTION
### Relevant Link:

https://allenai.atlassian.net/browse/GUNDI-4530

---

This pull request introduces several enhancements and fixes to the `client.py`, `handlers.py`, and related test files, focusing on improved error handling, token management, and playback observation functionality. 

The key changes include adding a new exception for handling expired tokens, updating retry logic, and modifying playback observation behavior to respect a maximum observation limit.

### Error Handling Improvements:
- **New Exception Class**: Added `ProTrackTokenExpiredException` to handle scenarios where the token has expired, providing a clear structure for managing this error. (`[app/actions/client.pyR58-R65](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013R58-R65)`)
- **Enhanced Retry Logic**: Updated the `@stamina.retry` decorator to include `ProTrackTokenExpiredException` and limit retry attempts to 2. (`[[1]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L121-R129)`, `[[2]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013R152-R179)`, `[[3]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L183-R201)`)

### Token Management Updates:
- **Token Expiry Handling**: Modified `get_devices` and `get_playback_observations` to raise `ProTrackTokenExpiredException` when a token expires, ensuring proper cleanup and re-authentication. (`[[1]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013R152-R179)`, `[[2]](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L183-R201)`)
- **Token Initialization in Playback**: Ensured `get_playback_observations` retrieves and sets the access token before fetching playback data. (`[app/actions/client.pyR152-R179](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013R152-R179)`)

### Playback Observation Enhancements:
- **Observation Limit**: Updated `get_playback_observations` to return a sorted list of observations, respecting the `max_observations` limit from the playback configuration. (`[app/actions/client.pyL202-R221](diffhunk://#diff-2ec2ed70abf8182f30b27698f142fa49dc3f1539f86eb84d0e5826523cb83013L202-R221)`)
- **PlaybackConfig Update**: Added a `max_observations` field to the `PlaybackConfig` class with a default value of 1000. (`[app/actions/configurations.pyL28-R39](diffhunk://#diff-0c07ea434f0a65b6e42dfb436000af783a7bd80e905bbed3d9cb7f67b779d895L28-R39)`)

### Code and Test Adjustments:
- **Parameter Refinements**: Updated exception handling in `action_pull_observations` and `action_playback` to pass `error` explicitly for better error tracking. (`[[1]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L102-R100)`, `[[2]](diffhunk://#diff-f575ea29ea1c9649ccb87f9c38a0fd9a78b9f210c9e5e9d800e328ee30d08113L145-R144)`)
- **Test Coverage**: Enhanced test cases for playback functionality by including account credentials in the integration configurations. (`[[1]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR108)`, `[[2]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR121)`, `[[3]](diffhunk://#diff-1d3087a4c8f5f87d441341225d93eba5a73d22523ef90b8f1903714bc31eb11fR148)`)